### PR TITLE
readme update - apikey encryption

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2024-07-26T09:11:57Z",
+  "generated_at": "2024-11-03T14:05:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### :warning: Important Security Notice
+
+> To enhance the security of your applications using the `ibm-appconfiguration-react-client-sdk`, it is strongly recommended to use an **encrypted APIKey** instead of the plain APIKey in the `AppConfigProvider`. This change is vital to prevent exposure of sensitive credentials when users inspect your web application. If you are already using a plain APIKey, please update your application to generate and use the encrypted APIKey as per the steps mentioned [here](./README_APIKEY_ENCRYPTION.md).
+
 # IBM App Configuration React Client SDK
 IBM Cloud App Configuration React Client SDK is used to perform feature flag and property evaluation in web applications and track custom metrics for Experimentation based on the configuration on IBM Cloud App Configuration service.
 
@@ -39,7 +43,7 @@ import { withAppConfigProvider } from 'ibm-appconfiguration-react-client-sdk';
   const AppConfigProvider = await withAppConfigProvider({
     region: 'us-south',
     guid: '<guid>',
-    apikey: '<apikey>',
+    apikey: '<encrypted_apikey>',
     collectionId: 'airlines-webapp',
     environmentId: 'dev'
   })
@@ -61,14 +65,14 @@ import { withAppConfigProvider } from 'ibm-appconfiguration-react-client-sdk';
     - `eu-de` for Frankfurt
 - guid : Instance Id of the App Configuration service. Obtain it from the service credentials section of the App
   Configuration dashboard.
-- apikey : ApiKey of the App Configuration service. Obtain it from the service credentials section of the App
-  Configuration dashboard.
+- apikey : The encrypted APIKey generated as described [here](./README_APIKEY_ENCRYPTION.md).
 - collectionId: Id of the collection created in App Configuration service instance under the **Collections** section.
 - environmentId: Id of the environment created in App Configuration service instance under the **Environments** section.
 
 :red_circle: **Important** :red_circle:
 
-Ensure to create the service credentials of the role **`Client SDK`** for using with the React SDK. API key of the **`Client SDK`** role has minimal access permissions that are suitable to use in browser based applications.
+Always use the encrypted APIKey to avoid exposing sensitive information.<br>
+Ensure that you create the service credentials with the **`Client SDK`** role, as it has the minimal access permissions that are suitable to use in browser-based applications.
 
 ## Get single feature
 
@@ -275,4 +279,4 @@ The SDK automatically subscribes to event-based mechanism and re-renders the enc
 ## License
 
 This project is released under the Apache 2.0 license. The license's full text can be found
-in [LICENSE](https://github.com/IBM/appconfiguration-js-client-sdk/blob/main/LICENSE)
+in [LICENSE](https://github.com/IBM/appconfiguration-react-client-sdk/blob/main/LICENSE)

--- a/README_APIKEY_ENCRYPTION.md
+++ b/README_APIKEY_ENCRYPTION.md
@@ -1,0 +1,52 @@
+# Encrypted APIKey Requirement
+
+The `ibm-appconfiguration-react-client-sdk` now requires users to provide an **Encrypted Client SDK APIKey** instead of the plain text APIKey in the `AppConfigProvider` to enhance security. This helps prevent exposure of the APIKey when inspecting the webpage through browsers.
+
+To provide maximum security, we utilize a random nonce during the encryption process. As a result, each time you encrypt your APIKey, the encrypted value will be different, but the underlying plain text remains the same when it is decrypted during authentication.
+
+## Steps to Generate and Use Encrypted Client SDK APIKey
+
+1. Obtain Your Plain APIKey:
+    - Navigate to the **Service Credentials** section of your App Configuration instance on the IBM Cloud dashboard.
+    - Generate a **`Client SDK`** role APIKey and copy the apikey from the service credentials.
+2. Encrypt Your APIKey:
+    - Use the following API endpoint to encrypt your plain APIKey
+        ```code
+        POST /apprapp/feature/v1/instances/<guid>/encrypt
+        ```
+
+        Example: `https://eu-gb.apprapp.cloud.ibm.com/apprapp/feature/v1/instances/720f9034-c990-4305-96d6-4f65ffacef2c/encrypt`
+    - In the body of the request, include your plain APIKey as follows:
+        ```code
+        {
+          "client_sdk_apikey": "your_plain_apikey"
+        }
+        ```
+
+    - The response will contain your AES-256 encrypted APIKey.
+3. Update Your AppConfigProvider Code:
+    - Replace the use of the plain APIKey in your application with the encrypted APIKey. Below is an updated example of how to initialize the SDK using the encrypted APIKey:
+        ```js
+        import { withAppConfigProvider } from 'ibm-appconfiguration-react-client-sdk';
+
+        (async () => {
+        const AppConfigProvider = await withAppConfigProvider({
+            region: 'us-south', // Specify your region
+            guid: '<guid>', // Instance ID from Service Credentials
+            apikey: '<encrypted_apikey>', // Use the encrypted APIKey
+            collectionId: 'airlines-webapp', // Your collection ID
+            environmentId: 'dev' // Your environment ID
+        })
+
+        ReactDOM.render(
+            <AppConfigProvider>
+                <YourApp />
+            </AppConfigProvider>,
+            document.getElementById('root')
+        );
+        })();
+        ```
+
+## Existing Users: Update Required
+
+If you are already using a plain APIKey, please update your application to generate and use the encrypted APIKey as per the steps above.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3042,12 +3042,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -6609,12 +6610,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },


### PR DESCRIPTION
- added security notice in the readme, asking users to update their applications and pass encrypted apikey instead of plain apikey
- steps added to encrypt the plain apikey
- update package-lock-.json by running `npm audit fix`